### PR TITLE
Update inspect binds

### DIFF
--- a/lua/pluto/cl/settings.lua
+++ b/lua/pluto/cl/settings.lua
@@ -1,12 +1,14 @@
 local pluto_fov = CreateConVar("pluto_fov", GetConVar "fov_desired":GetFloat(), FCVAR_ARCHIVE, "FOV Addend", 60, 160)
-local pluto_inspect = CreateConVar("pluto_inspect", 4, {FCVAR_ARCHIVE, FCVAR_UNLOGGED}, "Lifespan of +inspect menu", 2, 10)
+local pluto_inspect_toggle = CreateConVar("pluto_inspect_toggle", 0, {FCVAR_ARCHIVE, FCVAR_UNLOGGED}, "Makes the +inspect toggleable")
+local pluto_inspect_slider = CreateConVar("pluto_inspect_slider", 4, {FCVAR_ARCHIVE, FCVAR_UNLOGGED}, "Lifespan of +inspect menu", 2, 10)
 
 hook.Add("TTTPopulateSettingsMenu", "pluto_settings", function()
 	local cat = vgui.Create "ttt_settings_category"
 
 	cat:AddSlider("FOV", "pluto_fov")
 	cat:AddCheckBox("Disable Cosmetics", "pluto_disable_cosmetics")
-	cat:AddSlider("+inspect time", "pluto_inspect")
+	cat:AddCheckBox("Make +inspect menu toggleable", "pluto_inspect_toggle")
+	cat:AddSlider("+inspect time", "pluto_inspect_slider")
 	cat:InvalidateLayout(true)
 	cat:SizeToContents()
 	ttt.settings:AddTab("Pluto", cat)

--- a/lua/weapons/weapon_plutobase/cl_init.lua
+++ b/lua/weapons/weapon_plutobase/cl_init.lua
@@ -67,13 +67,12 @@ function SWEP:Deploy()
 end
 
 function SWEP:Holster(w)
-	if (IsValid(self.Showcase)) then
-		self.Showcase:Remove()
+	if (IsValid(pluto.Showcase)) then
+		pluto.Showcase:Remove()
 	end
 
 	return BaseClass.Holster(self, w)
 end
-
 
 concommand.Add("+inspect", function()
 	local self = ttt.GetHUDTarget():GetActiveWeapon()
@@ -88,17 +87,25 @@ concommand.Add("+inspect", function()
 		return
 	end
 
-	if IsValid(self.Showcase) then
-		self.Showcase.Start = CurTime() - 0.2
+	local toggle = GetConVar("pluto_inspect_toggle"):GetBool()
+	local lifespan = GetConVar("pluto_inspect_slider"):GetFloat()
+
+	if IsValid(pluto.Showcase) then
+		if (pluto.Showcase.Toggle) then
+			pluto.Showcase.Toggle = false
+			pluto.Showcase.Start = CurTime() - lifespan + 0.2
+		elseif (not toggle) then
+			pluto.Showcase.Start = CurTime() - 0.2
+		end
+		return
 	else
-		self.Showcase = pluto.ui.showcase(data)
-		self.Showcase.Start = CurTime()
+		pluto.Showcase = pluto.ui.showcase(data)
+		pluto.Showcase.Toggle = toggle
+		pluto.Showcase.Start = CurTime()
 	end
 
-	local lifespan = GetConVar("pluto_inspect"):GetFloat()
-
-	local t = self.Showcase.Think
-	function self.Showcase:Think()
+	local t = pluto.Showcase.Think
+	function pluto.Showcase:Think()
 		if (t) then
 			t(self)
 		end
@@ -107,10 +114,10 @@ concommand.Add("+inspect", function()
 		local frac = 1
 		if (diff < 0.2) then
 			frac = (diff / 0.2) ^ 0.5
-		elseif (diff > lifespan) then
+		elseif (diff > lifespan and not self.Toggle) then
 			frac = 0
 			self:Remove()
-		elseif (diff > (lifespan - 0.2)) then
+		elseif (diff > (lifespan - 0.2) and not self.Toggle) then
 			frac = 1 - ((diff - lifespan + 0.2) / 0.2) ^ 0.5
 		end
 
@@ -119,11 +126,7 @@ concommand.Add("+inspect", function()
 end)
 
 concommand.Add("-inspect", function(ply, cmd, args)
-	local self = ttt.GetHUDTarget():GetActiveWeapon()
-
-	if (not IsValid(self) or not IsValid(self.Showcase)) then
-		return
+	if (IsValid(pluto.Showcase)) then
+		pluto.Showcase:Remove()
 	end
-
-	self.Showcase:Remove()
 end)


### PR DESCRIPTION
Had to redo the commit because I accidentally made the inspectbind branch from the rewardprints branch which is still under review and it was a huge mess

First, I made it so that the showcase panel that is created by +inspect lasts for 4 seconds instead of 2 second. Because the panel used to pop up automatically when you deployed the weapon, only lasting for 2 seconds made sense. Since you now have to manually pull it up with +inspect, having it last longer works better.

I also made it so that whenever +inspect is pressed, it checks to see if there is already a showcase panel present, and resets the time on it if so. It used to just re-make it each time, but that would cause it to do the popup animation each time which was super annoying.

Lastly, I added functionality to -inspect, since I noticed the command was added to console but it didn't actually do anything.