### PR TITLE
Detectivestuff

### DIFF
--- a/lua/pluto/roles/passevent/sh_passevent_roles.lua
+++ b/lua/pluto/roles/passevent/sh_passevent_roles.lua
@@ -1,11 +1,22 @@
 hook.Add("TTTPrepareRoles", "passevent", function(Team, Role)
 	Role("Yaari Spy", "traitor")
 		:SetCalculateAmountFunc(function(total_players)
-			return total_players > 8 and 1 or 0
+			return 0
 		end)
 
 	Role("Descendant", "innocent")
 		:SetCalculateAmountFunc(function(total_players)
 			return 1
 		end)
+end)
+
+hook.Add("TTTRolesSelected", "passevent", function(plys)
+	if (#round.Players >= 8) then
+		for _, info in ipairs(round.Players) do
+			if info.Role.Name == "Traitor" then
+				info.Role = ttt.roles["Yaari Spy"]
+				break
+			end
+		end
+	end
 end)


### PR DESCRIPTION
 - Used the newly added TTTRolesSelected hook to change a Traitor into a Yaari Spy before the roles are completely assigned (It wouldn't make a difference for Yaari Spy to be changed from Traitors after roles are completely assigned but in the future custom roles might have different equipment or credits or whatever and then it would matter).

NOTE: The tttrw pull request needs to go through before this because of the new TTTRolesSelected hook