### PR TITLE
A couple more if checks for invalid mods

### DIFF
--- a/lua/pluto/inv/init.lua
+++ b/lua/pluto/inv/init.lua
@@ -328,7 +328,7 @@ function pluto.inv.retrieveitems(steamid, cb)
 
 				local mod = pluto.mods.byname[item.modname]
 
-				if (not wpn.Mods) then
+				if (not mod or not wpn.Mods) then
 					if (IsValid(ply)) then
 						ply:ChatPrint("Your item with id " .. item.gun_index .. " has mods when it shouldn't!")
 					end

--- a/lua/pluto/mods/sh_mods.lua
+++ b/lua/pluto/mods/sh_mods.lua
@@ -47,6 +47,11 @@ end
 
 function pluto.mods.getminmaxs(mod_data, item)
 	local mod = pluto.mods.byname[mod_data.Mod]
+	
+	if (not mod) then
+		return ""
+	end
+
 	local tier = mod.Tiers[mod_data.Tier] or mod.Tiers[#mod.Tiers]
 
 	local formatted = {}
@@ -64,6 +69,11 @@ end
 
 function pluto.mods.format(mod_data, gun)
 	local mod = pluto.mods.byname[mod_data.Mod]
+
+	if (not mod) then
+		return ""
+	end
+
 	local tier = mod.Tiers[mod_data.Tier]
 	local rolls = pluto.mods.getrolls(mod, mod_data.Tier, mod_data.Roll)
 
@@ -79,6 +89,10 @@ end
 
 function pluto.mods.getdescription(mod_data)
 	local mod = pluto.mods.byname[mod_data.Mod]
+
+	if (not mod) then
+		return ""
+	end
 
 	if (mod.Description) then
 		return mod.Description


### PR DESCRIPTION
I looked at any instance of accessing the pluto.mods.byname table and added an if check if I thought it were important, returning or continuing depending on context.