### PR TITLE
Chimp stuff

### DIFF
--- a/lua/pluto/events/rounds/chimp/sv_init.lua
+++ b/lua/pluto/events/rounds/chimp/sv_init.lua
@@ -2,10 +2,10 @@ resource.AddFile("sound/pluto/dkrap.ogg") -- REMOVE ME
 
 ROUND.Name = "Monke Mania"
 ROUND.BananasPerPlayer = 6
-ROUND.KillStealMin = 0.35
-ROUND.KillStealMax = 0.65
+ROUND.KillStealMin = 0.25
+ROUND.KillStealMax = 0.45
 ROUND.HealthPerBanana = 10
-ROUND.BananasPerEgg = 8
+ROUND.BananasPerEgg = 10
 ROUND.WinnerBonus = 3
 ROUND.CollisionGroup = COLLISION_GROUP_DEBRIS_TRIGGER
 
@@ -139,7 +139,7 @@ end)
 
 ROUND:Hook("TTTUpdatePlayerSpeed", function(self, state, ply, data)
 	if (state.playerscores and state.playerscores[ply]) then
-		data["chimp"] = 1.2 + math.min(0.5, (state.playerscores[ply] * 0.1))
+		data["chimp"] = 1.2 + math.min(0.4, (state.playerscores[ply] * 0.08))
 	end
 end)
 
@@ -214,12 +214,18 @@ end
 ROUND:Hook("PlayerSelectSpawnPosition", ROUND.ResetPosition)
 
 ROUND:Hook("TTTEndRound", function(self, state)
+	for _, ent in ipairs(state.bananas) do
+		if (IsValid(ent)) then
+			ent:Remove() -- DOES NOT WORK, PLEASE FIX
+		end
+	end
+
 	self:ChooseLeader(state)
 
 	state.leader:SetModelScale(1, 0)
 
 	for ply, score in pairs(state.playerscores) do
-		local togive = math.floor(score / self.BananasPerEgg)
+		local togive = math.floor((score + self.BananasPerEgg / 2) / self.BananasPerEgg)
 		pluto.db.instance(function(db)
 			pluto.inv.addcurrency(db, ply, "brainegg", togive)
 			ply:ChatPrint(white_text, "Monke get ", togive, " ", pluto.currency.byname.brainegg, white_text, " for hav ", score, " ", pluto.currency.byname._banna, white_text, "!")
@@ -243,7 +249,7 @@ end)
 
 function ROUND:SendUpdateBananas(state)
 	local left = -1
-	for _, ent in pairs(state.bananas) do
+	for _, ent in ipairs(state.bananas) do
 		if (IsValid(ent)) then
 			left = left + 1
 		end

--- a/lua/pluto/inv/currency/sv_currency.lua
+++ b/lua/pluto/inv/currency/sv_currency.lua
@@ -669,8 +669,15 @@ for name, values in pairs {
 		Pickup = function(ply)
 			if (ttt.GetCurrentRoundEvent() == "chimp" and ttt.GetRoundState() == ttt.ROUNDSTATE_ACTIVE) then
 				hook.Run("PlutoBannaPickup", ply)
-			elseif (player.GetCount() >= 6) then
-				pluto.rounds.prepare "chimp"
+			elseif (ttt.GetCurrentRoundEvent() ~= "chimp") then
+				if (player.GetCount() >= 6) then
+					pluto.rounds.prepare "chimp"
+				end
+
+				pluto.db.instance(function(db)
+					pluto.inv.addcurrency(db, ply, "brainegg", 1)
+					ply:ChatPrint(white_text, "You have received 1 ", pluto.currency.byname.brainegg, white_text, " for finding a banna!")
+				end)
 			end
 
 			return true


### PR DESCRIPTION
k 2 things
First of all, please look at and push this as soon as possible
Second of all, PLEASE figure out what I'm doing wrong where I say -- DOES NOT WORK, PLEASE FIX
 - Reduced bananas lost and stolen per kill
 - Changed BananasPerEgg from 8 to 10 and made it so that the increment starts at 5. So instead of getting an egg at 8, then another at 16, and then 24, you get the first one at 5, and then 15, and then 25, and so on. That gives everyone an easier time getting the first brain egg but keeps it hard to get more
 - Changed the run speed multiplies. After doing some rounds with people on the server live I decided these would be better.
 - Made it so that whoever finds the initial banna that starts a chimp round gets a brain egg for their efforts
 - TRIED fixing a bug where any leftover bannas at the end of a chimp round could be picked up during the Ending phase to activate another chimp round by removing all leftover bannas at the end of the round but failed. Once again, this is where I put -- DOES NOT WORK, PLEASE FIX because I can't figure out why it isn't working.