### PR TITLE
More monke changes

### DIFF
--- a/lua/pluto/events/rounds/chimp/cl_init.lua
+++ b/lua/pluto/events/rounds/chimp/cl_init.lua
@@ -70,7 +70,9 @@ end)
 
 function ROUND:Prepare(state)
 	state.Start = CurTime()
-	EmitSound("pluto/dkrap.ogg", vector_origin, -2, CHAN_STATIC, 1)
+	timer.Simple(1, function()
+		EmitSound("pluto/dkrap.ogg", vector_origin, -2, CHAN_STATIC, 1)
+	end)
 end
 
 ROUND:Hook("HUDPaint", function(self, state)

--- a/lua/pluto/events/rounds/chimp/sh_init.lua
+++ b/lua/pluto/events/rounds/chimp/sh_init.lua
@@ -14,9 +14,10 @@ function ROUND:TTTPrepareRoles(Team, Role)
 		:SetCalculateAmountFunc(function(total_players)
 			return 0
 		end)
+		:SetCanUseBuyMenu(false)
 		:SetCanSeeThroughWalls(false)
 end
 
 ROUND:Hook("TTTUpdatePlayerSpeed", function(self, state, ply, data)
-	data.chimp = 1.2 + math.min(0.4, (ply:GetNWInt("MonkeScore", 0) * 0.08))
+	data.chimp = 1.05 + math.min(0.1, (ply:GetNWInt("MonkeScore", 0) * 0.01))
 end)


### PR DESCRIPTION
 - Delayed music by 1 second so it doesn't get removed by map cleanup
 - SetCanUseBuyMenu to false for monke
 - Reduced move speed and increments
 - Removed bannas dropped on kill
 - Changed reward increment to 7, 14, 21, etc
 - Made it so if you get 7 bannas at any point you are guaranteed an egg at the end
 - Make players take 5 bleed damage every 5 seconds if they have 7+ bannas and have not picked up any or hit anyone in 20 seconds
 - Remove health gain from hitting people, besides kills