### PR TITLE
Round start stuff

### DIFF
--- a/lua/pluto/inv/ttt.lua
+++ b/lua/pluto/inv/ttt.lua
@@ -160,6 +160,8 @@ hook.Add("TTTEndRound", "pluto_endround", function()
 	end
 end)
 
+local pluto_loaded = {}
+
 hook.Add("TTTPlayerGiveWeapons", "pluto_loadout", function(ply)
 	local event = pluto.rounds.getcurrent()
 	
@@ -217,5 +219,24 @@ hook.Add("TTTPlayerGiveWeapons", "pluto_loadout", function(ply)
 	if (i7) then
 		pluto.NextWeaponSpawn = i7
 		ply:Give(i7.ClassName)
+	end
+
+	pluto_loaded[ply:SteamID64()] = true
+	return true
+end)
+
+hook.Add("TTTRoundStart", "pluto_loadout_fallback", function(plys)
+	for _, ply in ipairs(plys) do
+		if (not ply:Alive()) then
+			return
+		end
+
+		hook.Run("PlayerSetModel", ply)
+
+		if (not pluto_loaded[ply:SteamID64()]) then
+			ply:StripWeapons()
+			ply:StripAmmo()
+			hook.Run("PlayerLoadout", ply)
+		end
 	end
 end)


### PR DESCRIPTION
 - Made it so when the round starts, all living and active players have their player model updated (so on round 1 they have their model, and if they updated it pre-round).
 - Made it so when the round starts, if a player hasn't had the pluto loadout done to them, it tries to do it to them there. I don't know if this will fix the issue with players not receiving their loadout on round 1, but it's worth a shot. If that doesn't work, my next suggestion would be to increase the "ttt_firstpreptime" ConVar to give the server more time to register weapons as players load in.