### PR TITLE
Fix starduster bug

### DIFF
--- a/lua/pluto/inv/currency/sv_currency.lua
+++ b/lua/pluto/inv/currency/sv_currency.lua
@@ -229,7 +229,7 @@ for name, values in pairs {
 						end
 
 						local mod = table.shuffle(pluto.mods.getfor(baseclass.Get(item.ClassName), function(mod)
-							return mod.Type == "implicit" and not mod.PreventChange and not notallowed[mod.InternalName]
+							return mod.Type == "implicit" and mod.Tomeable and not notallowed[mod.InternalName]
 						end))[1]
 
 						if (mod) then

--- a/lua/pluto/mods/modifiers/arcane.lua
+++ b/lua/pluto/mods/modifiers/arcane.lua
@@ -17,6 +17,7 @@ function MOD:FormatModifier(index, roll)
 end
 
 MOD.NoCoined = true
+MOD.Tomeable = true
 
 MOD.Description = "Touch of the Arcane"
 

--- a/lua/pluto/mods/modifiers/coined.lua
+++ b/lua/pluto/mods/modifiers/coined.lua
@@ -19,6 +19,7 @@ end
 MOD.Description = "Gives 12% more currency rewards per modifier"
 
 MOD.NoCoined = true
+MOD.Tomeable = true
 
 MOD.Tiers = {
 	{ 1, 1 },

--- a/lua/pluto/mods/modifiers/diced.lua
+++ b/lua/pluto/mods/modifiers/diced.lua
@@ -16,6 +16,8 @@ function MOD:FormatModifier(index, roll)
 	return ""
 end
 
+MOD.Tomeable = true
+
 MOD.Description = "Rolls better numbers on modifiers"
 
 MOD.Tiers = {

--- a/lua/pluto/mods/modifiers/dropletted.lua
+++ b/lua/pluto/mods/modifiers/dropletted.lua
@@ -16,6 +16,8 @@ function MOD:FormatModifier(index, roll)
 	return ""
 end
 
+MOD.Tomeable = true
+
 MOD.Description = "Droplets can roll max modifiers"
 
 MOD.Tiers = {

--- a/lua/pluto/mods/modifiers/handed.lua
+++ b/lua/pluto/mods/modifiers/handed.lua
@@ -16,6 +16,8 @@ function MOD:FormatModifier(index, roll)
 	return ""
 end
 
+MOD.Tomeable = true
+
 MOD.Description = "Mods roll one tier lower 50% of the time"
 
 MOD.Tiers = {

--- a/lua/pluto/mods/modifiers/hearted.lua
+++ b/lua/pluto/mods/modifiers/hearted.lua
@@ -16,6 +16,8 @@ function MOD:FormatModifier(index, roll)
 	return ""
 end
 
+MOD.Tomeable = true
+
 MOD.Description = "Has an extra affix slot"
 
 MOD.ExtraAffixes = 1


### PR DESCRIPTION
Made it so guns only get implicits that are explicitly stated as tomeable, so that future implicit additions don't accidentally become tomeable.