### PR TITLE
Slightly Buffs quests and adds News Weekly: Cuban Pete.

### DIFF
--- a/lua/pluto/quests/_init.lua
+++ b/lua/pluto/quests/_init.lua
@@ -36,7 +36,7 @@ for _, id in pairs {
 	"dnatrack",
 	"fourcraft",
 	"sacrifices",
-	"burn",
+	--"burn",
 	"postround",
 	"minis",
 	"identify",

--- a/lua/pluto/quests/_init.lua
+++ b/lua/pluto/quests/_init.lua
@@ -40,6 +40,7 @@ for _, id in pairs {
 	"postround",
 	"minis",
 	"identify",
+	"cubanpete",
 
 	"halloween_nade",
 } do

--- a/lua/pluto/quests/_init.lua
+++ b/lua/pluto/quests/_init.lua
@@ -36,7 +36,7 @@ for _, id in pairs {
 	"dnatrack",
 	"fourcraft",
 	"sacrifices",
-	--"burn",
+	"burn",
 	"postround",
 	"minis",
 	"identify",

--- a/lua/pluto/quests/list/cubanpete.lua
+++ b/lua/pluto/quests/list/cubanpete.lua
@@ -1,0 +1,23 @@
+QUEST.Name = "Cuban Pete" --https://www.youtube.com/watch?v=O0__b2eLx84
+QUEST.Description = "Kill players (Rightfully) with explosive damage." 
+QUEST.Credits = "Len Kagamine"
+QUEST.Color = Color(250, 88, 24)
+QUEST.RewardPool = "weekly"
+
+function QUEST:Init(data)
+	data:Hook("DoPlayerDeath", function(data, vic, atk, dmg)
+		local succ = false
+
+		if (atk == data.Player and dmg:IsDamageType(DMG_BLAST)) then
+			succ = true
+		end
+
+		if (IsValid(atk) and atk:IsPlayer() and atk:GetRoleTeam() ~= vic:GetRoleTeam() and succ) then
+			data:UpdateProgress(1)
+		end
+	end)
+end
+
+function QUEST:GetProgressNeeded()
+	return math.random(45, 60)
+end

--- a/lua/pluto/quests/sh_quests.lua
+++ b/lua/pluto/quests/sh_quests.lua
@@ -18,16 +18,16 @@ pluto.quests.types = {
 		Name = "Hourly",
 		RewardPool = "hourly",
 		Time = 60 * 60,
-		Amount = 2,
-		Cooldown = 60 * 7.5,
+		Amount = 3,
+		Cooldown = 60 * 10,
 		Color = HexColor "7ef524",
 	},
 	{
 		Name = "Daily",
 		RewardPool = "daily",
 		Time = 60 * 60 * 24, -- day
-		Amount = 1,
-		Cooldown = 60 * 60 * 6,
+		Amount = 2,
+		Cooldown = 60 * 60 * 4,
 		Color = HexColor "fcde1d"
 	},
 	{
@@ -35,7 +35,7 @@ pluto.quests.types = {
 		RewardPool = "weekly",
 		Time = 60 * 60 * 24 * 7, -- week
 		Amount = 1,
-		Cooldown = 60 * 60 * 24 * 2,
+		Cooldown = 60 * 60 * 24,
 		Color = HexColor "ff1a1a"
 	},
 }

--- a/lua/pluto/quests/sh_quests.lua
+++ b/lua/pluto/quests/sh_quests.lua
@@ -18,7 +18,7 @@ pluto.quests.types = {
 		Name = "Hourly",
 		RewardPool = "hourly",
 		Time = 60 * 60,
-		Amount = 3,
+		Amount = 2,
 		Cooldown = 60 * 10,
 		Color = HexColor "7ef524",
 	},

--- a/lua/pluto/quests/sv_quest_rewards.lua
+++ b/lua/pluto/quests/sv_quest_rewards.lua
@@ -201,6 +201,18 @@ pluto.quests.rewards = {
 		},
 		{
 			Type = "currency",
+			Currency = "hand",
+			Amount = 2,
+			Shares = 1,
+		},
+		{
+			Type = "currency",
+			Currency = "dice",
+			Amount = 5,
+			Shares = 1,
+		},
+		{
+			Type = "currency",
 			Currency = "tp",
 			Amount = 1,
 			Shares = 1,

--- a/lua/pluto/quests/sv_quest_rewards.lua
+++ b/lua/pluto/quests/sv_quest_rewards.lua
@@ -309,36 +309,6 @@ pluto.quests.rewards = {
 		},
 		{
 			Type = "weapon",
-			ClassName = "weapon_cod4_ak47_silencer",
-			Tier = "promised",
-			Shares = 0.1,
-		},
-		{
-			Type = "weapon",
-			ClassName = "weapon_cod4_m4_silencer",
-			Tier = "promised",
-			Shares = 0.1,
-		},
-		{
-			Type = "weapon",
-			ClassName = "weapon_cod4_m14_silencer",
-			Tier = "promised",
-			Shares = 0.1,
-		},
-		{
-			Type = "weapon",
-			ClassName = "weapon_cod4_g3_silencer",
-			Tier = "promised",
-			Shares = 0.1,
-		},
-		{
-			Type = "weapon",
-			ClassName = "weapon_cod4_g36c_silencer",
-			Tier = "promised",
-			Shares = 0.1,
-		},
-		{
-			Type = "weapon",
 			RandomImplicit = true,
 			ModMin = 4,
 			MoxMax = 5,
@@ -362,7 +332,13 @@ pluto.quests.rewards = {
 			Type = "shard",
 			ModMin = 5,
 			ModMax = 5,
-			Shares = 1,
+			Shares = 0.5,
+		},
+				{
+			Type = "shard",
+			ModMin = 4,
+			ModMax = 5,
+			Shares = 0.5,
 		},
 	},
 	weekly = {
@@ -405,6 +381,12 @@ pluto.quests.rewards = {
 		{
 			Type = "shard",
 			Tier = "otherworldly",
+			Shares = 0.25,
+		},
+				{
+			Type = "shard",
+			ModMin = 5,
+			ModMax = 6,
 			Shares = 0.5,
 		},
 	},

--- a/lua/pluto/quests/sv_quest_rewards.lua
+++ b/lua/pluto/quests/sv_quest_rewards.lua
@@ -196,7 +196,7 @@ pluto.quests.rewards = {
 		{
 			Type = "currency",
 			Currency = "droplet",
-			Amount = 75,
+			Amount = 50,
 			Shares = 1,
 		},
 		{
@@ -332,7 +332,7 @@ pluto.quests.rewards = {
 			Type = "shard",
 			ModMin = 5,
 			ModMax = 5,
-			Shares = 0.5,
+			Shares = 0.25,
 		},
 				{
 			Type = "shard",
@@ -364,7 +364,7 @@ pluto.quests.rewards = {
 			Type = "weapon",
 			ModMin = 6,
 			ModMax = 6,
-			Shares = 1,
+			Shares = 0.5,
 		},
 		{
 			Type = "weapon",
@@ -381,7 +381,7 @@ pluto.quests.rewards = {
 		{
 			Type = "shard",
 			Tier = "otherworldly",
-			Shares = 0.25,
+			Shares = 0.1,
 		},
 				{
 			Type = "shard",

--- a/lua/pluto/quests/sv_quest_rewards.lua
+++ b/lua/pluto/quests/sv_quest_rewards.lua
@@ -178,7 +178,7 @@ pluto.quests.rewards = {
 		{
 			Type = "currency",
 			Currency = "tome",
-			Amount = 1,
+			Amount = 2,
 			Shares = 1,
 		},
 		{
@@ -191,6 +191,12 @@ pluto.quests.rewards = {
 			Type = "currency",
 			Currency = "pdrop",
 			Amount = 3,
+			Shares = 1,
+		},
+		{
+			Type = "currency",
+			Currency = "droplet",
+			Amount = 75,
 			Shares = 1,
 		},
 		{
@@ -208,7 +214,7 @@ pluto.quests.rewards = {
 		{
 			Type = "weapon",
 			Tier = "inevitable",
-			Shares = 2,
+			Shares = 3,
 		},
 		{
 			Type = "shard",
@@ -291,6 +297,36 @@ pluto.quests.rewards = {
 		},
 		{
 			Type = "weapon",
+			ClassName = "weapon_cod4_ak47_silencer",
+			Tier = "promised",
+			Shares = 0.1,
+		},
+		{
+			Type = "weapon",
+			ClassName = "weapon_cod4_m4_silencer",
+			Tier = "promised",
+			Shares = 0.1,
+		},
+		{
+			Type = "weapon",
+			ClassName = "weapon_cod4_m14_silencer",
+			Tier = "promised",
+			Shares = 0.1,
+		},
+		{
+			Type = "weapon",
+			ClassName = "weapon_cod4_g3_silencer",
+			Tier = "promised",
+			Shares = 0.1,
+		},
+		{
+			Type = "weapon",
+			ClassName = "weapon_cod4_g36c_silencer",
+			Tier = "promised",
+			Shares = 0.1,
+		},
+		{
+			Type = "weapon",
 			RandomImplicit = true,
 			ModMin = 4,
 			MoxMax = 5,
@@ -312,18 +348,12 @@ pluto.quests.rewards = {
 		},
 		{
 			Type = "shard",
-			ModMin = 4,
+			ModMin = 5,
 			ModMax = 5,
 			Shares = 1,
 		},
 	},
 	weekly = {
-		{
-			Type = "currency",
-			Currency = "tome",
-			Amount = 25,
-			Shares = 0.5,
-		},
 		{
 			Type = "currency",
 			Currency = "coin",
@@ -343,14 +373,8 @@ pluto.quests.rewards = {
 			Shares = 1,
 		},
 		{
-			Type = "currency",
-			Currency = "stardust",
-			Amount = 25,
-			Shares = 1,
-		},
-		{
 			Type = "weapon",
-			ModMin = 5,
+			ModMin = 6,
 			ModMax = 6,
 			Shares = 1,
 		},
@@ -368,9 +392,8 @@ pluto.quests.rewards = {
 		},
 		{
 			Type = "shard",
-			ModMin = 5,
-			ModMax = 5,
-			Shares = 1,
+			Tier = "otherworldly",
+			Shares = 0.5,
 		},
 	},
 }

--- a/lua/pluto/quests/sv_quest_rewards.lua
+++ b/lua/pluto/quests/sv_quest_rewards.lua
@@ -184,13 +184,13 @@ pluto.quests.rewards = {
 		{
 			Type = "currency",
 			Currency = "aciddrop",
-			Amount = 3,
+			Amount = 5,
 			Shares = 1,
 		},
 		{
 			Type = "currency",
 			Currency = "pdrop",
-			Amount = 3,
+			Amount = 5,
 			Shares = 1,
 		},
 		{
@@ -214,7 +214,7 @@ pluto.quests.rewards = {
 		{
 			Type = "currency",
 			Currency = "tp",
-			Amount = 1,
+			Amount = 5,
 			Shares = 1,
 		},
 		{
@@ -239,8 +239,12 @@ pluto.quests.rewards = {
 			Tier = "promised",
 			Shares = 0.5,
 		},
-	},
-	daily = {
+		{
+			Type = "currency",
+			Currency = "crate0",
+			Amount = 1,
+			Shares = 1,
+		},
 		{
 			Type = "currency",
 			Currency = "crate2",
@@ -253,6 +257,8 @@ pluto.quests.rewards = {
 			Amount = 1,
 			Shares = 0.1,
 		},
+	},
+	daily = {
 		{
 			Type = "currency",
 			Currency = "crate3",
@@ -268,8 +274,8 @@ pluto.quests.rewards = {
 		{
 			Type = "currency",
 			Currency = "tp",
-			Amount = 5,
-			Shares = 1.5,
+			Amount = 25,
+			Shares = 1,
 		},
 		{
 			Type = "currency",
@@ -357,7 +363,7 @@ pluto.quests.rewards = {
 		{
 			Type = "currency",
 			Currency = "tp",
-			Amount = 50,
+			Amount = 75,
 			Shares = 1,
 		},
 		{


### PR DESCRIPTION
Adds the maraca man himself, cuban pete, and makes quests slightly more worth it.

Additions:
Cuban Pete Weekly: Rightfully end players(45-60) with explosives! Frag out!
Changes:
Quests are now 2 hourlies, 2 Dailys, and 1 Weekly.
You get 2 tomes instead of one from dailies.
Acidics and plutonics from dailies are now 5(from 3)
Refined: 
Hourly 1>5
Daily- 5>25
Weekly- 50 >75
Orange and Blue eggs can now be found in hourlies (from dailies)
You can now get 2 hands from an hourly
You can now get 50 droplets from an hourly
You can now get 5 dice from an hourly
"Inevitable" rewards are now 50% more common from hourlies
You can no longer get tomes from weeklies.
You can no longer get stardust from weeklies
Hourlies refresh every 10 minutes, up from 7.5
Dailies refresh every 4 hours, down from 6
Weeklies refresh every day, down from 2



